### PR TITLE
Does not add commented lines.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+{
+    "version": "0.1.0",
+    "configurations": [
+
+        {
+            "name": "Launch Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
+            "preLaunchTask": "npm"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+// Available variables which can be used inside of strings.
+// ${workspaceRoot}: the root folder of the team
+// ${file}: the current opened file
+// ${fileBasename}: the current opened file's basename
+// ${fileDirname}: the current opened file's dirname
+// ${fileExtname}: the current opened file's extension
+// ${cwd}: the current working directory of the spawned process
+
+// A task runner that calls a custom npm script that compiles the extension.
+{
+    "version": "0.1.0",
+
+    // we want to run npm
+    "command": "npm",
+
+    // the command is a shell script
+    "isShellCommand": true,
+
+    // show the output window only if unrecognized errors occur.
+    "showOutput": "silent",
+
+    // we run the custom script "compile" as defined in package.json
+    "args": ["run", "compile", "--loglevel", "silent"],
+
+    // The tsc compiler is started in watching mode
+    "isBackground": true,
+
+    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
+    "problemMatcher": "$tsc-watch"
+}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
-        "typescript": "^2.0.3",
+        "typescript": "^2.3.1",
         "vscode": "^1.0.0",
         "mocha": "^2.3.3",
         "@types/node": "^6.0.40",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,9 +35,9 @@ export function activate(context: ExtensionContext) {
 
       // Let's do search for now
       for (let lineIndex = 0; lineIndex < doc.lineCount; lineIndex++) {
-        const lineText = doc.lineAt(lineIndex).text;
+        const lineText: string = doc.lineAt(lineIndex).text;
 
-        if (lineText.length) {
+        if (lineText.length && lineText.charAt(0) !== '#') {
           let lineTextWithPath = lineText;
           if (dir !== '.') {
             lineTextWithPath = dir + '/' + lineText;


### PR DESCRIPTION
With this change, the extension doesn't add the line if it begins with `#`, which denotes a comment. I also fixed the extension debugging code by adding a couple required json files.

Side note, my "Fixes #3" commit note is incorrect. That is an outstanding issue, I tried to solve it but couldn't.